### PR TITLE
Add support for setting margins of each navigation items.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-osx_image: xcode611
 script:
-    - xctool -scheme 'UINavigationItem+Margin' -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test
+    - xctool -scheme 'UINavigationItem+Margin' -sdk iphonesimulator7.1 CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test
+    - xctool -scheme 'UINavigationItem+Margin' -sdk iphonesimulator8.1 CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO test

--- a/README.md
+++ b/README.md
@@ -7,35 +7,43 @@ UINavigationItem+Margin
 Margin for UINavigationItem.
 
 
-At a Glance
------------
+Setting Margins
+---------------
 
-In your `AppDelegate.m` (or anywhere you want to use it):
+Just set `leftMargin` and `rightMargin` of your UINavigationItem.
 
 ```objc
-[UINavigationItem setMargin:-16];
+navigationItem.leftMargin = 0;
+navigationItem.rightMargin = 0;
 ```
 
-![](https://cloud.githubusercontent.com/assets/931655/5898748/e1d333a0-a595-11e4-85a3-9a492d1d38fc.png)
+![zero](https://cloud.githubusercontent.com/assets/931655/5898748/e1d333a0-a595-11e4-85a3-9a492d1d38fc.png)
 
 Wow, margin has disappeared.
 
-If you don't like magic number such as `-16`, you can use `removeSystemMargin` for the same result:
+Even you can do this:
 
 ```objc
-[UINavigationItem removeSystemMargin]; // -16 in iOS 7
+navigationItem.leftMargin = 50;
+navigationItem.rightMargin = 20;
 ```
 
-You can use both of them:
+![ugly](https://cloud.githubusercontent.com/assets/931655/6410361/12d1c69e-beb2-11e4-9cf6-7f7d9469ef09.png)
+
+Looks ugly but works.
+
+
+System Margins
+--------------
+
+Want to restore margins? Use `[UINavigationItem systemMargin]`.
 
 ```objc
-[UINavigationItem removeSystemMargin];
-[UINavigationItem setMargin:12];
+navigationItem.leftMargin = [UINavigationItem systemMargin]; // 16 on iOS 7+
+navigationItem.rightMargin = [UINavigationItem systemMargin];
 ```
 
-![](https://cloud.githubusercontent.com/assets/931655/5898749/e1d72cc6-a595-11e4-84b7-e7fd3e116567.png)
-
-Awesome, looks great.
+![system](https://cloud.githubusercontent.com/assets/931655/6410333/d42763d6-beb1-11e4-845e-34002d336034.png)
 
 
 Installation
@@ -53,4 +61,4 @@ pod 'UINavigationItem+Margin'
 License
 -------
 
-UINavigationItem+Margin is under MIT license. See the LICENSE file for more info.
+**UINavigationItem+Margin** is under MIT license. See the LICENSE file for more info.

--- a/UINavigationItem+Margin/UINavigationItem+Margin.h
+++ b/UINavigationItem+Margin/UINavigationItem+Margin.h
@@ -29,12 +29,9 @@ FOUNDATION_EXPORT const unsigned char UINavigationItem_MarginVersionString[];
 
 @interface UINavigationItem (Margin)
 
-+ (CGFloat)systemMargin;
-+ (void)removeSystemMargin;
-+ (void)restoreSystemMargin;
-+ (BOOL)systemMarginRemoved;
+@property (nonatomic, assign) CGFloat leftMargin;
+@property (nonatomic, assign) CGFloat rightMargin;
 
-+ (CGFloat)margin;
-+ (void)setMargin:(CGFloat)margin;
++ (CGFloat)systemMargin;
 
 @end


### PR DESCRIPTION
### Setting Margins

``` objc
navigationItem.leftMargin = 0;
navigationItem.rightMargin = 0;
```

![zero](https://cloud.githubusercontent.com/assets/931655/5898748/e1d333a0-a595-11e4-85a3-9a492d1d38fc.png)

``` objc
navigationItem.leftMargin = 50;
navigationItem.rightMargin = 20;
```

![ugly](https://cloud.githubusercontent.com/assets/931655/6410361/12d1c69e-beb2-11e4-9cf6-7f7d9469ef09.png)
### System Margins

``` objc
navigationItem.leftMargin = [UINavigationItem systemMargin]; // 16 on iOS 7+
navigationItem.rightMargin = [UINavigationItem systemMargin];
```

![system](https://cloud.githubusercontent.com/assets/931655/6410333/d42763d6-beb1-11e4-845e-34002d336034.png)
