### PR TITLE
Fix a bug that margin won't be set for bar button items from xib.

### DIFF
--- a/UINavigationItem+Margin/UINavigationItem+Margin.m
+++ b/UINavigationItem+Margin/UINavigationItem+Margin.m
@@ -117,7 +117,12 @@
 
 - (NSArray *)originalLeftBarButtonItems
 {
-    return objc_getAssociatedObject(self, @selector(originalLeftBarButtonItems));
+    NSArray *items = objc_getAssociatedObject(self, @selector(originalLeftBarButtonItems));
+    if (!items) {
+        items = [self swizzled_leftBarButtonItems];
+        self.originalLeftBarButtonItems = items;
+    }
+    return items;
 }
 
 - (void)setOriginalLeftBarButtonItems:(NSArray *)items
@@ -127,7 +132,12 @@
 
 - (NSArray *)originalRightBarButtonItems
 {
-    return objc_getAssociatedObject(self, @selector(originalRightBarButtonItems));
+    NSArray *items = objc_getAssociatedObject(self, @selector(originalRightBarButtonItems));
+    if (!items) {
+        items = [self swizzled_rightBarButtonItems];
+        self.originalRightBarButtonItems = items;
+    }
+    return items;
 }
 
 - (void)setOriginalRightBarButtonItems:(NSArray *)items


### PR DESCRIPTION
Setting bar button items from xib won't call `setLeftBarButtonItem:`. Take existing bar button items when returning original bar button items.
- Related issue: #2
